### PR TITLE
fix for tornadohandler

### DIFF
--- a/src/greplin/scales/tornadohandler.py
+++ b/src/greplin/scales/tornadohandler.py
@@ -57,4 +57,4 @@ class StatsHandler(tornado.web.RequestHandler):
       formats.htmlHeader(self, '/' + path, self.serverName, query)
       formats.htmlFormat(self, tuple(parts), statDict, query)
 
-    return ''
+    return None


### PR DESCRIPTION
tornado.web.RequestHandler should return None or Future, as per change in
tornado.git:ca8495d934f659dffb7350f2e7df77b59b39e0b5
