### PR TITLE
Python3 compatibility for UserDict

### DIFF
--- a/src/greplin/scales/__init__.py
+++ b/src/greplin/scales/__init__.py
@@ -27,7 +27,11 @@ except ImportError:
 import time
 from contextlib import contextmanager
 
-from UserDict import UserDict
+import sys
+if sys.version_info.major >=3:
+  from collections import UserDict
+else:
+  from UserDict import UserDict
 from greplin.scales.samplestats import UniformSample
 
 ID_KEY = '__STATS__id'


### PR DESCRIPTION
Check python version before trying to import UserDict, get it from collections if 3+, from UserDict otherwise.
