### PR TITLE
Fix syntax error on bad if/else/elif

### DIFF
--- a/src/greplin/scales/graphite.py
+++ b/src/greplin/scales/graphite.py
@@ -105,11 +105,13 @@ class GraphitePusher(object):
         self.push(value, '%s%s.' % (prefix, self._sanitize(name)), subpath)
       elif self._forbidden(subpath, value):
         continue
+
       if six.PY3:
         type_values = (int, float)
       else:
         type_values = (int, long, float)
-      elif type(value) in type_values and len(name) < 500:
+
+      if type(value) in type_values and len(name) < 500:
         self.graphite.log(prefix + self._sanitize(name), value)
 
 


### PR DESCRIPTION
It looks like the 1.0.5 release has a syntax error in greplin.py
