### PR TITLE
Relax simplejson dependency to >= 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='scales',
       url='https://www.github.com/Cue/scales',
       install_requires=[
         'nose',
-        'simplejson==3.3.3',
+        'simplejson>=3.0.0',
         'six',
       ],
       package_dir = {'':'src'},


### PR DESCRIPTION
Python3 support was added to simplejson in 3.0.0, so any version after
that should be fine.  Strictly requiring 3.3.3 can introduce version
conflicts with other libraries.
