### PR TITLE
Don't install nose along with scales

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name='scales',
       author_email='opensource@greplin.com',
       url='https://www.github.com/Cue/scales',
       install_requires=[
-        'nose',
         'simplejson==3.3.3',
         'six',
       ],


### PR DESCRIPTION
Please don’t add test tools as runtime dependencies.
