### PR TITLE
Don't check for iteritems and encode to binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,6 @@ setup(name='scales',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.3',
+          'Programming Language :: Python :: 3.4',
     ],
 )

--- a/src/greplin/scales/aggregation.py
+++ b/src/greplin/scales/aggregation.py
@@ -364,8 +364,7 @@ class Aggregation(object):
     if data is None:
       return
 
-    # Checks for both a python 2 or python 3 dictionary
-    if hasattr(aggregators, 'iteritems') or hasattr(aggregators, 'items'):
+    if hasattr(aggregators, 'items'):
       # Keep walking the tree.
       for key, value in six.iteritems(aggregators):
         if isinstance(key, tuple):

--- a/src/greplin/scales/graphite.py
+++ b/src/greplin/scales/graphite.py
@@ -101,7 +101,7 @@ class GraphitePusher(object):
           value = None
           logging.exception('Error when calling stat function for graphite push')
 
-      if hasattr(value, 'iteritems'):
+      if hasattr(value, 'items'):
         self.push(value, '%s%s.' % (prefix, self._sanitize(name)), subpath)
       elif self._forbidden(subpath, value):
         continue

--- a/src/greplin/scales/util.py
+++ b/src/greplin/scales/util.py
@@ -15,6 +15,7 @@
 """Useful utility functions and objects."""
 
 from six.moves.queue import Queue
+from six import binary_type
 from math import exp
 
 import logging
@@ -94,6 +95,9 @@ class GraphiteReporter(threading.Thread):
     """Send a line to graphite. Retry with exponential backoff."""
     if not self.sock:
       self.connect()
+    if not isinstance(msg, binary_type):
+      msg = msg.encode("UTF-8")
+
     backoff = 0.001
     while True:
       try:


### PR DESCRIPTION
Fixes graphite to work on Python 3.  Should fix #35.

I have also removed another instance of checking for `iteritems` *and* `items` because it doesn’t make any sense: both Python 2 and 3 have `items`, the difference is that the former returns a list and the later is identical to 2’s `iteritems`.

The code is also littered with `list()` calls on generators which doesn’t make much sense and only slows everything down.  I kept this PR minimal though.

Let me know if you have any questions.