### PR TITLE
Avoid logging at root and prefer debug to info level for code in loops

### DIFF
--- a/src/greplin/scales/graphite.py
+++ b/src/greplin/scales/graphite.py
@@ -26,6 +26,9 @@ from socket import gethostname
 
 import six
 
+logger = logging.getLogger(__name__)
+
+
 class GraphitePusher(object):
   """A class that pushes all stat values to Graphite on-demand."""
 
@@ -99,7 +102,7 @@ class GraphitePusher(object):
           value = value()
         except:                       # pylint: disable=W0702
           value = None
-          logging.exception('Error when calling stat function for graphite push')
+          logger.exception('Error when calling stat function for graphite push')
 
       if hasattr(value, 'items'):
         self.push(value, '%s%s.' % (prefix, self._sanitize(name)), subpath)
@@ -161,12 +164,12 @@ class GraphitePeriodicPusher(threading.Thread, GraphitePusher):
     """Loop forever, pushing out stats."""
     self.graphite.start()
     while True:
-      logging.info('Graphite pusher is sleeping for %d seconds', self.period)
+      logger.debug('Graphite pusher is sleeping for %d seconds', self.period)
       time.sleep(self.period)
-      logging.info('Pushing stats to Graphite')
+      logger.debug('Pushing stats to Graphite')
       try:
         self.push()
-        logging.info('Done pushing stats to Graphite')
+        logger.debug('Done pushing stats to Graphite')
       except:
-        logging.exception('Exception while pushing stats to Graphite')
+        logger.exception('Exception while pushing stats to Graphite')
         raise


### PR DESCRIPTION
The current graphite code clutters logs with info level log entries each time it pushes. On top of that, since it logs at the root level there is no way to disable this logging without disabling info level logging for all other code. This PR has two changes:

1. Log using the module name so that the log level could be configured specifically for this module
2. Switch from info to debug so that the following lines don't appear in info level logs every 60 seconds:

Graphite pusher is sleeping for 60 seconds
Pushing stats to Graphite
Done pushing stats to Graphite

Thanks!