### PR TITLE
Logging Refinement

### DIFF
--- a/src/greplin/scales/graphite.py
+++ b/src/greplin/scales/graphite.py
@@ -26,6 +26,9 @@ from socket import gethostname
 
 import six
 
+log = logging.getLogger(__name__)
+
+
 class GraphitePusher(object):
   """A class that pushes all stat values to Graphite on-demand."""
 
@@ -99,7 +102,7 @@ class GraphitePusher(object):
           value = value()
         except:                       # pylint: disable=W0702
           value = None
-          logging.exception('Error when calling stat function for graphite push')
+          log.exception('Error when calling stat function for graphite push')
 
       if hasattr(value, 'items'):
         self.push(value, '%s%s.' % (prefix, self._sanitize(name)), subpath)
@@ -161,12 +164,12 @@ class GraphitePeriodicPusher(threading.Thread, GraphitePusher):
     """Loop forever, pushing out stats."""
     self.graphite.start()
     while True:
-      logging.info('Graphite pusher is sleeping for %d seconds', self.period)
+      log.debug('Graphite pusher is sleeping for %d seconds', self.period)
       time.sleep(self.period)
-      logging.info('Pushing stats to Graphite')
+      log.debug('Pushing stats to Graphite')
       try:
         self.push()
-        logging.info('Done pushing stats to Graphite')
+        log.debug('Done pushing stats to Graphite')
       except:
-        logging.exception('Exception while pushing stats to Graphite')
+        log.exception('Exception while pushing stats to Graphite')
         raise

--- a/src/greplin/scales/util.py
+++ b/src/greplin/scales/util.py
@@ -24,6 +24,8 @@ import socket
 import threading
 import time
 
+log = logging.getLogger(__name__)
+
 
 def lookup(source, keys, fallback = None):
   """Traverses the source, looking up each key.  Returns None if can't find anything instead of raising an exception."""
@@ -104,7 +106,7 @@ class GraphiteReporter(threading.Thread):
         self.sock.sendall(msg)
         break
       except socket.error:
-        logging.warning('Graphite connection error', exc_info = True)
+        log.warning('Graphite connection error', exc_info = True)
         self.disconnect()
         time.sleep(random.uniform(0, 2.0*backoff))
         backoff = min(backoff*2.0, 5.0)


### PR DESCRIPTION
Some possible refinements to logging:

1.) Module-specific logging; avoids having to deal with these messages at the root logger.
2.) Make graphite push logging 'debug', which seemed more appropriate for this type of log.