### PR TITLE
Py38 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
   - TOX_ENV=py32
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py35
+  - TOX_ENV=py36
+  - TOX_ENV=py37
+  - TOX_ENV=py38
 
 install:
   - pip install tox

--- a/src/greplin/scales/formats.py
+++ b/src/greplin/scales/formats.py
@@ -16,7 +16,11 @@
 
 from greplin import scales
 
-import cgi
+try:
+  import html
+except ImportError:
+  # Python 2.7 has no html module
+  import cgi as html
 import six
 import json
 import operator
@@ -105,7 +109,7 @@ def _htmlRenderDict(pathParts, statDict, output):
 
   output.write('<div class="level">')
   for key in keys:
-    keyStr = cgi.escape(_utf8str(key))
+    keyStr = html.escape(_utf8str(key))
     value = statDict[key]
     if hasattr(value, '__call__'):
       value = value()
@@ -119,7 +123,7 @@ def _htmlRenderDict(pathParts, statDict, output):
         _htmlRenderDict(valuePath, value, output)
     else:
       output.write('<div><span class="key">%s</span> <span class="%s">%s</span></div>' %
-                   (keyStr, type(value).__name__, cgi.escape(_utf8str(value)).replace('\n', '<br/>')))
+                   (keyStr, type(value).__name__, html.escape(_utf8str(value)).replace('\n', '<br/>')))
 
   if links:
     for link in links:

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [tox]
-envlist = py27, pypy, py32, py33, py34
+envlist = py27, pypy, py32, py33, py34, py35, py36, py37, py38
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
Fixes compatibility with Python 3.8 and adds newer Pythons to tox and travis configurations.

Could you please release a new version with this fix?